### PR TITLE
chore(2.3.0): Add manual trigger for website deployment.

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -3,6 +3,7 @@ name: Deploy Website
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
# Summary
This pull requests add the possibility of triggering the website deployment workflow manually.