### PR TITLE
chore(2.3.0): Add deploy permissions.

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -23,6 +23,9 @@ jobs:
           path: "public/"
 
   deploy:
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{steps.deployment.outputs.page_url}}


### PR DESCRIPTION
# Summary
This pull request adds the correct permissions for deploying the website to GitHub Pages.